### PR TITLE
Fix recipe routing after Google Drive sync

### DIFF
--- a/index.html
+++ b/index.html
@@ -412,7 +412,7 @@
   // Routing: react to hash
   const route = () => {
     const match = location.hash.match(/recipe=([\w-]+)/);
-    if (match && dirHandle) renderRecipe(match[1]);
+    if (match) renderRecipe(match[1]);
   };
   window.addEventListener('hashchange', route);
 


### PR DESCRIPTION
- Remove dirHandle requirement from route() function
- Synced recipes are stored in slugToFile but dirHandle is null
- This was preventing recipe content from loading after sync
- Now works for both local files and synced recipes

🤖 Generated with [Claude Code](https://claude.ai/code)